### PR TITLE
ci: remove scheduled trigger from cli-version-check

### DIFF
--- a/.github/workflows/cli-version-check.yml
+++ b/.github/workflows/cli-version-check.yml
@@ -1,8 +1,6 @@
 name: CLI Version Check
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # Daily 00:00 UTC
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Remove the daily `schedule` trigger from `cli-version-check.yml`
- Retain `workflow_dispatch` for manual on-demand runs

## Motivation

Claude Code Action is now billed separately from the subscription quota, making daily automated runs cost-ineffective.